### PR TITLE
test(run.sh): 'set -eu' cause script to exit if cfn-lint rc is not equal. Caused security scans to be skipped.

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -u
 
 SCRIPT_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 ROOT_PATH="$SCRIPT_PATH/.."


### PR DESCRIPTION
'set -eu' cause script to exit if cfn-lint rc is not equal. Caused security scans to be skipped.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
