### PR TITLE
fix: tests / checkov: secrets scan results #25 - CKV_SECRET_6 finding - False positive, excluded

### DIFF
--- a/env/instances/kubecost.yaml
+++ b/env/instances/kubecost.yaml
@@ -168,6 +168,7 @@ spec:
       existingSecret: ''
     envFromSecret: ''
     affinity: {}
+    #checkov:skip=CKV_SECRET_6:Default/Initial password, to be changed during the Workshop, not an actual secret.
     adminPassword: strongpassword
     livenessProbe:
       failureThreshold: 10


### PR DESCRIPTION
tests / checkov: secrets scan results #25 - CKV_SECRET_6 finding - False positive, excluded

*Issue #, if available:*

Fixes #25 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
