### PR TITLE
fix: tests / checkov: kubernetes scan results - Findings addressed by excludes or code adjustments

### DIFF
--- a/env/bin/deploy-ldap.yml
+++ b/env/bin/deploy-ldap.yml
@@ -23,6 +23,16 @@ metadata:
     app: ldap
     app.kubernetes.io/component: ldap
     app.kubernetes.io/instance: ldap
+  annotations:
+    checkov.io/skip1: CKV_K8S_43=Demo/Workshop environment, we don't need a fixed hash.
+    checkov.io/skip2: CKV_K8S_15=Demo/Workshop environment, we don't need to allways pull the image.
+    checkov.io/skip3: CKV_K8S_22=Demo/Workshop environment, not necessary to enforce read-only filesystem.
+    checkov.io/skip4: CKV_K8S_40=OpenShift will assign a random UUID for the User.
+    checkov.io/skip5: CKV_K8S_31=Demo/Workshop environment, not necessary to enforce a seccomp profile.
+    checkov.io/skip6: CKV_K8S_11=Demo/Workshop environment, CPU limits can be ignored.
+    checkov.io/skip7: CKV_K8S_13=Demo/Workshop environment, Memory limits can be ignored.
+    checkov.io/skip8: CKV_K8S_21=Demo/Workshop environment, Usage of default namespace is fine.
+    checkov.io/skip9: CKV2_K8S_6=Demo/Workshop environment, not necessary to drop capabilities.
   name: ldap
 spec:
   progressDeadlineSeconds: 600
@@ -44,6 +54,7 @@ spec:
       labels:
         deployment: ldap
     spec:
+      automountServiceAccountToken: false
       containers:
       - env:
         - name: LDAP_ROOT
@@ -126,6 +137,8 @@ metadata:
     app: ldap
     app.kubernetes.io/component: ldap
     app.kubernetes.io/instance: ldap
+  annotations:
+    checkov.io/skip8: CKV_K8S_21=Demo/Workshop environment, Usage of default namespace is fine.
   name: ldap
 spec:
   internalTrafficPolicy: Cluster

--- a/env/instances/ssm.yaml
+++ b/env/instances/ssm.yaml
@@ -38,6 +38,14 @@ apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: ssm-agent-installer
+  annotations:
+    checkov.io/skip1: CKV_K8S_5=allowPrivilegeEscalation required for SSM Agent Installer.
+    checkov.io/skip2: CKV_K8S_7=NET_RAW capability required for SSM Agent Installer.
+    checkov.io/skip3: CKV_K8S_36=Capabilities required for SSM Agent Installer.
+    checkov.io/skip4: CKV_K8S_2=Privileged container required for SSM Agent Installer.
+    checkov.io/skip5: CKV_K8S_6=Root container required for SSM Agent Installer.
+    checkov.io/skip6: CKV_K8S_32=Demo/Workshop environment, not necessary to enforce a seccomp profile.
+    checkov.io/skip7: CKV_K8S_1=HostPID required for SSM Agent Installer.
 spec:
   privileged: true
   hostPID: true 
@@ -70,6 +78,25 @@ kind: DaemonSet
 metadata:
   name: ssm-agent-installer
   namespace: ssm-agent
+  annotations:
+    checkov.io/skip1: CKV_K8S_20=allowPrivilegeEscalation required by SSM Agent Installer.
+    checkov.io/skip2: CKV_K8S_11=Demo/Workshop environment, CPU limits can be ignored.
+    checkov.io/skip3: CKV_K8S_10=Demo/Workshop environment, CPU requests can be ignored.
+    checkov.io/skip4: CKV_K8S_28=NET_RAW capability required by SSM Agent Installer.
+    checkov.io/skip5: CKV_K8S_43=Demo/Workshop environment, we don't need a fixed hash
+    checkov.io/skip6: CKV_K8S_15=Demo/Workshop environment, we don't need to allways pull the image.
+    checkov.io/skip7: CKV_K8S_13=Demo/Workshop environment, Memory limits can be ignored.
+    checkov.io/skip8: CKV_K8S_12=Demo/Workshop environment, Memory requests can be ignored.
+    checkov.io/skip9: CKV_K8S_22=Demo/Workshop environment, not necessary to enforce read-only filesystem.
+    checkov.io/skip10: CKV_K8S_40=OpenShift will assign a random UUID for the User.
+    checkov.io/skip11: CKV_K8S_31=Demo/Workshop environment, not necessary to enforce a seccomp profile.
+    checkov.io/skip12: CKV_K8S_17=HostPID required for SSM Agent Installer.
+    checkov.io/skip13: CKV_K8S_16=Privileged permissions required by SSM Agent Installer.
+    checkov.io/skip14: CKV_K8S_37=Capabilities required by SSM Agent Installer.
+    checkov.io/skip15: CKV_K8S_29=Privileged permissions required by SSM Agent Installer.
+    checkov.io/skip16: CKV2_K8S_6=Demo/Workshop environment, not necessary to drop capabilities.
+    checkov.io/skip17: CKV_K8S_9=Readiness Probe not available for ssm agent installer deployments.
+    checkov.io/skip18: CKV_K8S_8=LivenessProbe not available for ssm agent installer deployments.
 spec:
   selector:
     matchLabels:
@@ -79,6 +106,7 @@ spec:
       labels:
         job: ssm-agent-installer
     spec:
+      automountServiceAccountToken: false
       hostPID: true
       restartPolicy: Always
       initContainers:

--- a/templates/cdk/x-ray/demo-app/k8s-deploy.yaml
+++ b/templates/cdk/x-ray/demo-app/k8s-deploy.yaml
@@ -5,6 +5,17 @@ kind: Deployment
 metadata:
   name: service-a
   namespace: aws-xray
+  annotations:
+    checkov.io/skip1: CKV_K8S_9=Demo/Workshop environment, skip readiness probe.
+    checkov.io/skip2: CKV_K8S_31=Demo/Workshop environment, not necessary to enforce a seccomp profile.
+    checkov.io/skip3: CKV_K8S_14=Application container only available with latest tag.
+    checkov.io/skip4: CKV_K8S_22=Demo/Workshop environment, not necessary to enforce read-only filesystem.
+    checkov.io/skip5: CKV_K8S_43=Demo/Workshop environment, we don't need a fixed hash.
+    checkov.io/skip6: CKV_K8S_8=Demo/Workshop environment, skip liveness probe.
+    checkov.io/skip7: CKV_K8S_40=OpenShift will assign a random UUID for the User.
+    checkov.io/skip8: CKV_K8S_29=False positive, security context defined.
+    checkov.io/skip9: CKV_K8S_21=Demo/Workshop environment, Usage of default namespace is fine.
+    checkov.io/skip10: CKV2_K8S_6=Demo/Workshop environment, not necessary to drop capabilities.
 spec:
   replicas: 2 # tells deployment to run 2 pods matching the template
   selector:
@@ -15,6 +26,7 @@ spec:
       labels:
         app: service-a
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: service-a
           image: ckassen/aws-xray-kubernetes-service-a:latest
@@ -49,6 +61,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: service-a
+  annotations:
+    checkov.io/skip9: CKV_K8S_21=Demo/Workshop environment, Usage of default namespace is fine.
 spec:
   selector:
     app: service-a
@@ -66,6 +80,17 @@ kind: Deployment
 metadata:
   name: service-b
   namespace: aws-xray
+  annotations:
+    checkov.io/skip1: CKV_K8S_9=Demo/Workshop environment, skip readiness probe.
+    checkov.io/skip2: CKV_K8S_31=Demo/Workshop environment, not necessary to enforce a seccomp profile.
+    checkov.io/skip3: CKV_K8S_14=Application container only available with latest tag.
+    checkov.io/skip4: CKV_K8S_22=Demo/Workshop environment, not necessary to enforce read-only filesystem.
+    checkov.io/skip5: CKV_K8S_43=Demo/Workshop environment, we don't need a fixed hash.
+    checkov.io/skip6: CKV_K8S_8=Demo/Workshop environment, skip liveness probe.
+    checkov.io/skip7: CKV_K8S_40=OpenShift will assign a random UUID for the User.
+    checkov.io/skip8: CKV_K8S_29=False positive, security context defined.
+    checkov.io/skip9: CKV_K8S_21=Demo/Workshop environment, Usage of default namespace is fine.
+    checkov.io/skip10: CKV2_K8S_6=Demo/Workshop environment, not necessary to drop capabilities.
 spec:
   replicas: 2 # tells deployment to run 2 pods matching the template
   selector:
@@ -76,6 +101,7 @@ spec:
       labels:
         app: service-b
     spec:
+      automountServiceAccountToken: false
       containers:
         - name: service-b
           image: ckassen/aws-xray-kubernetes-service-b:latest
@@ -108,6 +134,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: service-b
+  annotations:
+    checkov.io/skip9: CKV_K8S_21=Demo/Workshop environment, Usage of default namespace is fine.
 spec:
   selector:
     app: service-b

--- a/templates/cdk/x-ray/xray-daemon/xray-k8s-daemonset.yaml
+++ b/templates/cdk/x-ray/xray-daemon/xray-k8s-daemonset.yaml
@@ -35,6 +35,15 @@ kind: DaemonSet
 metadata:
   name: xray-daemon
   namespace: aws-xray
+  annotations:
+    checkov.io/skip1: CKV_K8S_9=Demo/Workshop environment, skip readiness probe.
+    checkov.io/skip2: CKV_K8S_14=Application container only available with latest tag.
+    checkov.io/skip3: CKV_K8S_22=Demo/Workshop environment, not necessary to enforce read-only filesystem.
+    checkov.io/skip4: CKV_K8S_43=Demo/Workshop environment, we don't need a fixed hash.
+    checkov.io/skip5: CKV_K8S_8=Demo/Workshop environment, skip liveness probe.
+    checkov.io/skip6: CKV_K8S_40=OpenShift will assign a random UUID for the User.
+    checkov.io/skip7: CKV2_K8S_6=Demo/Workshop environment, not necessary to drop capabilities.
+    checkov.io/skip8: CKV_K8S_15=Demo/Workshop environment, we don't need to allways pull the image.
 spec:
   updateStrategy:
     type: RollingUpdate
@@ -46,6 +55,7 @@ spec:
       labels:
         app: xray-daemon
     spec:
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
         seccompProfile:
@@ -57,7 +67,7 @@ spec:
             name: "xray-config"
       containers:
         - name: xray-daemon
-          image: amazon/aws-xray-daemon
+          image: amazon/aws-xray-daemon:3.x
           command: ["/usr/bin/xray", "-c", "/aws/xray/config.yaml"]
           securityContext:
             allowPrivilegeEscalation: false


### PR DESCRIPTION
tests / checkov: kubernetes scan results - Failed checks: 67, Skipped checks: 0 - Issue #24 - Findings addressed by excludes or code adjustments.

*Issue #, if available:*

Fixes #24 

*Description of changes:*

A few changes in the manifest files, e.g. disable automount of service account token. Mostly exclusions because of false positives, capabilities requires by the container or uncritical findings given that it's demo/workshop/sample code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
